### PR TITLE
fix broken build and #92, use Adaptive Icons for shortcuts

### DIFF
--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/MainActivity.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/MainActivity.java
@@ -2,6 +2,7 @@ package de.szalkowski.activitylauncher;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;


### PR DESCRIPTION
When creating shortcuts on API>=26, should prefer AdaptiveIcon over Icon.