### PR TITLE
Add roundness to the dialogs

### DIFF
--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/DisclaimerDialogFragment.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/DisclaimerDialogFragment.java
@@ -1,11 +1,11 @@
 package de.szalkowski.activitylauncher;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.PreferenceManager;
 

--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/IconPickerDialogFragment.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/IconPickerDialogFragment.java
@@ -1,6 +1,5 @@
 package de.szalkowski.activitylauncher;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
@@ -10,6 +9,7 @@ import android.widget.GridView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
 public class IconPickerDialogFragment extends DialogFragment implements IconListAsyncProvider.Listener<IconListAdapter> {

--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/ShortcutEditDialogFragment.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/ShortcutEditDialogFragment.java
@@ -1,6 +1,5 @@
 package de.szalkowski.activitylauncher;
 
-import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.ComponentName;
 import android.content.Context;
@@ -17,6 +16,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.preference.PreferenceManager;

--- a/ActivityLauncherApp/src/main/java/org/thirdparty/LauncherIconCreator.java
+++ b/ActivityLauncherApp/src/main/java/org/thirdparty/LauncherIconCreator.java
@@ -12,7 +12,6 @@
 package org.thirdparty;
 
 import android.annotation.TargetApi;
-import android.app.AlertDialog;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -30,6 +29,7 @@ import android.os.Bundle;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/ActivityLauncherApp/src/main/res/values/themes.xml
+++ b/ActivityLauncherApp/src/main/res/values/themes.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight" />
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight">
+        <item name="dialogCornerRadius">24dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
Contains these two changes which are complementary,

```
Add roundness to app dialog
    
    As one small and simple change to make the app look more up to dated.
```

```
Use androidx AlertDialog instead of system provided
    
    It is just an unification as androidx.preference already uses
    that over system provided AlertDialog.
```

(as roundness will be applied to AndroidX provided dialogs which preference already use)

Which turns

<img width="341" alt="image" src="https://user-images.githubusercontent.com/833473/152541864-0b5a4ef8-16b1-48c4-8bf6-7b2b5223c209.png">

Into 

<img width="337" alt="image" src="https://user-images.githubusercontent.com/833473/152541933-28af5ecb-116e-45d7-a335-745f99d677fb.png">

which matches newer Android versions, however,

<img width="337" alt="image" src="https://user-images.githubusercontent.com/833473/152542070-017ea3f3-6792-43b8-ae3b-93d3a68ddacf.png">

<img width="335" alt="image" src="https://user-images.githubusercontent.com/833473/152542166-a4027dbd-47e6-45df-b833-e22de2cad506.png">

Aren't changed as they aren't AlertDialog and the ProgressDialog one is deprecated and probably better to be replaced anyway,

<img width="671" alt="image" src="https://user-images.githubusercontent.com/833473/152542400-986c91ea-b3de-4358-83c6-97581e6dbbcc.png">


