### PR TITLE
Bring context menu on three dots clicks

### DIFF
--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/AllTasksListAdapter.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/AllTasksListAdapter.java
@@ -6,6 +6,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -115,7 +116,7 @@ public class AllTasksListAdapter extends BaseExpandableListAdapter implements Fi
 
         binding.icon.setImageDrawable(activity.getIcon());
 
-        binding.button1.setOnClickListener(view1 -> binding.getRoot().performLongClick());
+        binding.button1.setOnClickListener(this::bringContextMenu);
 
         return binding.getRoot();
     }
@@ -149,7 +150,7 @@ public class AllTasksListAdapter extends BaseExpandableListAdapter implements Fi
 
         binding.icon.setImageDrawable(pack.getIcon());
 
-        binding.button1.setOnClickListener(view1 -> binding.getRoot().performLongClick());
+        binding.button1.setOnClickListener(this::bringContextMenu);
 
         // expand if filtered list is short enough
         if (this.filtered.size() < 10) {
@@ -158,6 +159,12 @@ public class AllTasksListAdapter extends BaseExpandableListAdapter implements Fi
         }
 
         return binding.getRoot();
+    }
+
+    private void bringContextMenu(View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            view.getParent().showContextMenuForChild(view, 0, 0);
+        else view.performLongClick();
     }
 
     @Override


### PR DESCRIPTION
Currently we have two kind of behavior, a regular context menu shown
on long clicks and a dialog created from menu items on kebab menu clicks.

Other than the fact the latter uses a system alert dialog which isn't themeable,
it feels the behavior is inconsistent, if any of the behavior is intended
it should happen on both cases and alert dialog created from menu items
feels like a last resort of Android view system to offer something even
if it can't actually get click position correctly and doesn't feel to be
intended canonical behavior from reading the Android's source:

https://android.googlesource.com/platform/frameworks/base/+/c741f70ac2acf5a37cbc8198e9309e53284c463b/core/java/com/android/internal/policy/DecorView.java#855

This change make the two consistent by delivering correct click position
so a context menu will be shown on both cases and if the case is the show
a dialog here, it should happen both on long clicks and kebab menu clicks.

This turns

![](https://user-images.githubusercontent.com/833473/152542070-017ea3f3-6792-43b8-ae3b-93d3a68ddacf.png)

Into

<img width="336" alt="image" src="https://user-images.githubusercontent.com/833473/155016838-d98b4ba0-aa90-49c2-9116-ba0fd81361a0.png">

which I believe was intended initially.
