### PR TITLE
allow to modify the action and data

### DIFF
--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/RootLauncherIconCreator.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/RootLauncherIconCreator.java
@@ -2,6 +2,7 @@ package de.szalkowski.activitylauncher;
 
 import android.content.ComponentName;
 import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
 import android.widget.Toast;
 
@@ -9,6 +10,10 @@ import org.thirdparty.LauncherIconCreator;
 
 public class RootLauncherIconCreator {
     public static void createLauncherIcon(Context context, MyActivityInfo activity) {
+        createLauncherIcon(context, activity, null, null);
+    }
+
+    public static void createLauncherIcon(Context context, MyActivityInfo activity, String action, Uri data) {
         var signer = new Signer(context);
         var extras = new Bundle();
         var comp = activity.getComponentName();
@@ -29,6 +34,6 @@ public class RootLauncherIconCreator {
         activity.is_private = true;
         activity.component_name = new ComponentName("de.szalkowski.activitylauncher", "de.szalkowski.activitylauncher.RootLauncherActivity");
 
-        LauncherIconCreator.createLauncherIcon(context, activity, extras);
+        LauncherIconCreator.createLauncherIcon(context, activity, extras, action, data);
     }
 }

--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/ShortcutEditDialogFragment.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/ShortcutEditDialogFragment.java
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -51,6 +52,10 @@ public class ShortcutEditDialogFragment extends DialogFragment {
         binding.editTextName.setText(this.activity.name);
         binding.editTextPackage.setText(this.activity.component_name.getPackageName());
         binding.editTextClass.setText(this.activity.component_name.getClassName());
+        binding.checkBoxAction.setOnCheckedChangeListener((buttonView, isChecked) -> binding.editTextAction.setEnabled(isChecked));
+        binding.editTextAction.setEnabled(binding.checkBoxAction.isChecked());
+        binding.checkBoxData.setOnCheckedChangeListener((buttonView, isChecked) -> binding.editTextData.setEnabled(isChecked));
+        binding.editTextData.setEnabled(binding.checkBoxData.isChecked());
         binding.editTextIcon.setText(this.activity.icon_resource_name);
         binding.checkBoxAsRoot.setChecked(asRoot);
         binding.checkBoxAsRoot.setEnabled(rooted);
@@ -131,10 +136,24 @@ public class ShortcutEditDialogFragment extends DialogFragment {
                         Toast.makeText(getActivity(), R.string.error_invalid_icon_format, Toast.LENGTH_LONG).show();
                     }
 
-                    if (as_root) {
-                        RootLauncherIconCreator.createLauncherIcon(getActivity(), ShortcutEditDialogFragment.this.activity);
+                    final String action;
+                    if (binding.checkBoxAction.isChecked()) {
+                        action = binding.editTextAction.getText().toString();
                     } else {
-                        LauncherIconCreator.createLauncherIcon(getActivity(), ShortcutEditDialogFragment.this.activity);
+                        action = null;
+                    }
+
+                    final Uri data;
+                    if (binding.checkBoxData.isChecked()) {
+                        data = Uri.parse(binding.editTextData.getText().toString());
+                    } else {
+                        data = null;
+                    }
+
+                    if (as_root) {
+                        RootLauncherIconCreator.createLauncherIcon(getActivity(), ShortcutEditDialogFragment.this.activity, action, data);
+                    } else {
+                        LauncherIconCreator.createLauncherIcon(getActivity(), ShortcutEditDialogFragment.this.activity, action, data);
                     }
                 })
                 .setNegativeButton(android.R.string.cancel, (dialog, which) -> Objects.requireNonNull(ShortcutEditDialogFragment.this.getDialog()).cancel());

--- a/ActivityLauncherApp/src/main/java/org/thirdparty/LauncherIconCreator.java
+++ b/ActivityLauncherApp/src/main/java/org/thirdparty/LauncherIconCreator.java
@@ -24,6 +24,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
 import android.graphics.drawable.LayerDrawable;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.widget.Toast;
@@ -45,7 +46,7 @@ import de.szalkowski.activitylauncher.R;
 
 public class LauncherIconCreator {
 
-    private static Intent getActivityIntent(ComponentName activity, Bundle extras) {
+    private static Intent getActivityIntent(ComponentName activity, Bundle extras, String action, Uri data) {
         Intent intent = new Intent();
         intent.setComponent(activity);
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -55,10 +56,20 @@ public class LauncherIconCreator {
             intent.putExtras(extras);
         }
 
+        if (action != null) {
+            intent.setAction(action);
+        } else {
+            intent.setAction(Intent.ACTION_CREATE_SHORTCUT);
+        }
+
+        if (data != null) {
+            intent.setData(data);
+        }
+
         return intent;
     }
 
-    public static void createLauncherIcon(Context context, MyActivityInfo activity, Bundle extras) {
+    public static void createLauncherIcon(Context context, MyActivityInfo activity, Bundle extras, String action, Uri data) {
         String pack = null;
 
         if (activity.getIconResouceName() != null && activity.getIconResouceName().indexOf(':') >= 0) {
@@ -66,7 +77,7 @@ public class LauncherIconCreator {
         }
 
         String name = activity.getName();
-        Intent intent = getActivityIntent(activity.getComponentName(), extras);
+        Intent intent = getActivityIntent(activity.getComponentName(), extras, action, data);
         Drawable icon = activity.getIcon();
 
 
@@ -79,7 +90,11 @@ public class LauncherIconCreator {
     }
 
     public static void createLauncherIcon(Context context, MyActivityInfo activity) {
-        createLauncherIcon(context, activity, null);
+        createLauncherIcon(context, activity, null, null);
+    }
+
+    public static void createLauncherIcon(Context context, MyActivityInfo activity, String action, Uri data) {
+        createLauncherIcon(context, activity, null, action, data);
     }
 
     public static void createLauncherIcon(Context context, MyPackageInfo pack) {
@@ -136,7 +151,7 @@ public class LauncherIconCreator {
      * https://stackoverflow.com/questions/12343227/escaping-bash-function-arguments-for-use-by-su-c
      */
     public static void launchActivity(Context context, ComponentName activity, boolean asRoot) {
-        Intent intent = LauncherIconCreator.getActivityIntent(activity, null);
+        Intent intent = LauncherIconCreator.getActivityIntent(activity, null, null, null);
         Toast.makeText(context, String.format(context.getText(R.string.starting_activity).toString(), activity.flattenToShortString()),
                 Toast.LENGTH_LONG).show();
 
@@ -233,7 +248,6 @@ public class LauncherIconCreator {
 
         if (shortcutManager.isRequestPinShortcutSupported()) {
             Icon icon = getIconFromDrawable(draw);
-            intent.setAction(Intent.ACTION_CREATE_SHORTCUT);
 
             ShortcutInfo shortcutInfo = new ShortcutInfo.Builder(context, appName)
                     .setShortLabel(appName)

--- a/ActivityLauncherApp/src/main/res/layout/dialog_edit_activity.xml
+++ b/ActivityLauncherApp/src/main/res/layout/dialog_edit_activity.xml
@@ -82,6 +82,62 @@
                 android:inputType="text" />
         </TableRow>
 
+
+        <TableRow>
+            <TextView
+                android:id="@+id/textView_action"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:labelFor="@+id/editText_action"
+                android:text="@string/label_action"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <EditText
+                android:id="@+id/editText_action"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:importantForAutofill="no"
+                android:inputType="text"
+                android:text="android.intent.action.VIEW" />
+
+            <CheckBox
+                android:id="@+id/checkBox_action"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+        </TableRow>
+
+        <TableRow
+            android:id="@+id/tableRow_data"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/textView_data"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:labelFor="@+id/editText_data"
+                android:text="@string/label_data"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <EditText
+                android:id="@+id/editText_data"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:importantForAutofill="no"
+                android:inputType="text" />
+
+            <CheckBox
+                android:id="@+id/checkBox_data"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical" />
+        </TableRow>
+
         <TableRow
             android:id="@+id/tableRow_icon"
             android:layout_width="wrap_content"

--- a/ActivityLauncherApp/src/main/res/values/strings.xml
+++ b/ActivityLauncherApp/src/main/res/values/strings.xml
@@ -52,4 +52,6 @@
     <string name="theme_default">System Default</string>
     <string name="theme_light">Light Theme</string>
     <string name="theme_dark">Dark Theme</string>
+    <string name="label_data">Data</string>
+    <string name="label_action">Action</string>
 </resources>


### PR DESCRIPTION
This is more or less a proof of concept to set data and modify action.

Related to #154

Actually

* it is not possible to set data
* action is set hard to `android.intent.action.CREATE_SHORTCUT`

If you want to open a custom URL in e.g. Firefox you have to an intent with

* action: `android.intent.action.VIEW`
* component: package: `org.mozilla.firefox`, class: `org.mozilla.fenix.IntentReceiverActivity`
* data: the URL to open

This modification allows to set a data. If the checkbox is not checked, no data is set.

This modification allows to set a custom action. If the checkbox is not checked, the old CREATE_SHORTCUT one is used. If the checkbox is set, the given one is used. The deactivated text box for the action contains the VIEW action as this allows me easily testing without adding the text all the time. Perhaps we could drop the checkbox and use a dropdown list with the commonly used ones (+ the option to add a custom text).

I would be interested if this makes sense for you at all.