### PR TITLE
fix: more startup crashes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "de.szalkowski.activitylauncher"
         minSdk = 16
         targetSdk = 36
-        versionCode = 55
-        versionName = "2.0.5"
+        versionCode = 56
+        versionName = "2.0.6"
 
         multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Should definitely fix this one:

![image](https://github.com/user-attachments/assets/2ce1e760-af11-48d8-a4f4-0e6d4d078d92)

Not sure where this one is coming from, can the packageName be null instead of String? Any other possible reason?
Added some extra verbose checks for that - but not sure if this is the reason. Please check @EnaSko 

![image](https://github.com/user-attachments/assets/c500292c-3299-458e-a06e-67964f2128ed)
